### PR TITLE
Fix rust builder tags

### DIFF
--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           images: ${{ env.registry }}/${{ github.repository_owner }}/rust_builder
           tags: |
+            type=raw,value=${{ matrix.toolchain_version }}-latest
             type=raw,value=${{ matrix.rust_version.major }}.${{ matrix.rust_version.minor }}.${{ matrix.rust_version.patch }}-${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}
             type=raw,value=${{ matrix.rust_version.major }}.${{ matrix.rust_version.minor }}-${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}
             type=schedule,pattern=${{ matrix.rust_version.major }}.${{ matrix.rust_version.minor }}.${{ matrix.rust_version.patch }}-${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}-{{date 'YYYYMMDD'}}


### PR DESCRIPTION
_TL;DR:_ Fix `rust_builder` Docker image tag

## Before
The tags for `rust_builder` are currently being generated as follows:
<img width="606" alt="Screenshot 2022-11-11 at 12 43 57" src="https://user-images.githubusercontent.com/11741977/201401830-a1b2afce-e1c9-42a7-8908-33325d2f3ad8.png">

Please note the `Object.Object-bullseye-nightly-20221111` tag for example:
- it's being created during scheduled builds
- it uses`${rust_version}` for variable expansion, thus the value `Object`

Also, note the `latest` tag. This doesn't make a lot of sense since it can point to either `stable` or `nightly`.

## After
This change fixes the wrongly generated tags, using the appropriate environment variables in the pipeline.
It should replace the `Object.Object` value by the correct `${rust_version.major}.${rust_version.minor}`.

Also the `latest` tag ~was completely removed~ was changed to `${toolchain_version}-latest`, producing `nightly-latest` and `stable-latest`.