### PR TITLE
ci: Add support for multiplatform build

### DIFF
--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -65,5 +71,6 @@ jobs:
             DEBIAN_SUITE=${{ matrix.debian_suite }}
           context: ./rust_builder/
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
_TL;DR:_ Add support for multi-platform builds

## Before
We currently run jobs using [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners). With the default configuration, Docker will build images targeting the underlying architecture.

[Docker](https://docs.docker.com/get-started/) is a set of tools that leverages the usage of [OS-level virtualization](https://en.wikipedia.org/wiki/OS-level_virtualization) to create [containers](https://www.docker.com/resources/what-container/). The key idea is to offer isolated environments to run user programs, sharing a single OS Kernel. Please, note that since the Kernel is shared, the underlying machine architecture is inherited as well. 

Traditionally in UNIX (like) based systems, there is a command called [`uname`](https://en.wikipedia.org/wiki/Uname) that allows users to query name, version and other details about the current machine and the operating system. For example:

```
# show all
$ uname -a
Darwin Thiagos-MBP-2 22.1.0 Darwin Kernel Version 22.1.0: Sun Oct  9 20:15:09 PDT 2022; root:xnu-8792.41.9~2/RELEASE_ARM64_T6000 arm64

# show only machine architecture
$ uname -m
arm64
```

And from a container:
```
$ docker run --rm -it debian:stable-slim bash
root@f332c474096a:/# uname -m
aarch64
```

The issue arrises when images are built in one architecture, and containers run in a different one:
```
$ docker run --rm -it ghcr.io/toposware/rust_builder:1.65.0-bullseye-nightly-20221112 bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
root@483f8e1f0af3:/# uname -m
x86_64
```

# After
More recently, Docker included in its installation the new [BuildX](https://github.com/docker/buildx) client that support hardware emulation through [QEMU](https://www.qemu.org/). With this, it's possible to build [Docker images targeting multiple platforms](https://docs.docker.com/build/building/multi-platform/), providing additional flags to the build command.

After this change, images for `amd64` and `arm64` will be natively supported, improving the whole CI/CD and local development experience.

For example:
```
$ docker run --rm -it ghcr.io/toposware/rust_builder:stable-latest bash                   
root@a5ae83272087:/# uname -m
aarch64
```

It's possible to observe that the command above returns `aarch64` (arm64), but was built using GitHub-hosted runners (amd64). To force the usage of a specific architecture, passing the `--platform` argument:

```
$ docker run --platform=linux/amd64 --rm -it ghcr.io/toposware/rust_builder:stable-latest bash
root@0d56760d7531:/# uname -m
x86_64
```

This shows that the pipeline built multi-platform images.