### PR TITLE
fix: set 90 minutes timeout

### DIFF
--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
_TLDR:_ Set 90 minutes timeout for the rust builder job

## Before
Currently the [rust builder job](https://github.com/toposware/topos-ci-docker/blob/f1ba16ecbab3674391d033b90da6dc34ddd45b18/.github/workflows/rust_builder.yml) has a 6 hours timeout. More recently, some jobs seem to be [getting stuck](https://github.com/toposware/topos-ci-docker/actions/workflows/rust_builder.yml).

## After
This change decreases the timeout limit to 90 minutes. From a quick look, seems that the jobs should take 40 minutes on average, leaving enough extra time.