### PR TITLE
fix: use regular runners

### DIFF
--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -3,7 +3,6 @@ name: k8s_e2e
 on:
   push:
     branches:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 env:
@@ -11,7 +10,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     name: Build and push k8s_e2e:latest
     steps:

--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -6,7 +6,6 @@ on:
     - cron: "30 5 * * *"
   push:
     branches:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 env:
@@ -14,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description

Runners used in CI workflows are Github larger runners which are not available outside Team and Enterprise paid plans. This PR updates workflows runners to Github regular `ubuntu-latest` runners.

## Additions and Changes

- Update runners to `ubuntu-latest` in all CI workflows

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
