### PR TITLE
fix: rust_builder

### DIFF
--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -66,6 +66,6 @@ jobs:
             DEBIAN_SUITE=${{ matrix.debian_suite }}
           context: ./rust_builder/
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -66,6 +66,6 @@ jobs:
             DEBIAN_SUITE=${{ matrix.debian_suite }}
           context: ./rust_builder/
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -59,7 +59,7 @@ jobs:
             type=schedule,pattern=${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}-{{date 'YYYYMMDD'}}
 
       - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           build-args: |
             TOOLCHAIN_VERSION=${{ matrix.toolchain_version }}

--- a/rust_builder/Dockerfile
+++ b/rust_builder/Dockerfile
@@ -5,6 +5,7 @@ RUN apt update && \
     apt install -y clang cmake protobuf-compiler libprotobuf-dev
 
 ARG TOOLCHAIN_VERSION
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_TERM_COLOR=always
 ENV RUSTFLAGS=-Dwarnings
 ENV RUST_BACKTRACE=1

--- a/rust_builder/Dockerfile
+++ b/rust_builder/Dockerfile
@@ -12,4 +12,4 @@ ENV RUST_BACKTRACE=1
 
 RUN rustup toolchain install ${TOOLCHAIN_VERSION} && \
     rustup default ${TOOLCHAIN_VERSION} && \
-    cargo install cargo-chef sccache --locked
+    cargo install sccache --locked


### PR DESCRIPTION
# Description

- Bump `build-push-action`
- Increase timeout to 180 minutes
- set `CARGO_NET_GIT_FETCH_WITH_CLI=true`

## Additions and Changes

There are [known issues](https://github.com/docker/build-push-action/issues/621) with Docker `build-push-action` when building for `arm64` architecture. It became more clear when our jobs started failing with `137 error code`, after the GitHub Actions runner type was changed.

In this PR we follow the solution proposed in the [issue](https://github.com/docker/build-push-action/issues/621), that suggests that setting `CARGO_NET_GIT_FETCH_WITH_CLI=true` fixes the `Killed 137` error.

## PR Checklist:

- [] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
