### PR TITLE
chore: update protoc compiler

### DIFF
--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   registry: ghcr.io
+  protobuf_compiler: https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
 
 jobs:
   build-and-push-image:
@@ -29,8 +30,6 @@ jobs:
         exclude:
           - scheduled: true
             toolchain_version: stable
-        protobuf_compiler:
-          - https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
 
     name: Build and push rust_builder:${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}
     steps:
@@ -66,7 +65,7 @@ jobs:
           build-args: |
             TOOLCHAIN_VERSION=${{ matrix.toolchain_version }}
             DEBIAN_SUITE=${{ matrix.debian_suite }}
-            PROTOBUF_COMPILER=${{  matrix.protobuf_compiler }}
+            PROTOBUF_COMPILER=${{ env.protobuf_compiler }}
           context: ./rust_builder/
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/rust_builder.yml
+++ b/.github/workflows/rust_builder.yml
@@ -29,6 +29,8 @@ jobs:
         exclude:
           - scheduled: true
             toolchain_version: stable
+        protobuf_compiler:
+          - https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip
 
     name: Build and push rust_builder:${{ matrix.debian_suite }}-${{ matrix.toolchain_version }}
     steps:
@@ -64,6 +66,7 @@ jobs:
           build-args: |
             TOOLCHAIN_VERSION=${{ matrix.toolchain_version }}
             DEBIAN_SUITE=${{ matrix.debian_suite }}
+            PROTOBUF_COMPILER=${{  matrix.protobuf_compiler }}
           context: ./rust_builder/
           push: true
           platforms: linux/amd64,linux/arm64

--- a/rust_builder/Dockerfile
+++ b/rust_builder/Dockerfile
@@ -2,7 +2,12 @@ ARG DEBIAN_SUITE
 FROM rust:${DEBIAN_SUITE}
 
 RUN apt update && \
-    apt install -y clang cmake protobuf-compiler libprotobuf-dev
+    apt install -y clang cmake wget unzip
+
+ARG PROTOBUF_COMPILER
+RUN wget ${PROTOBUF_COMPILER} && \
+    unzip ${PROTOBUF_COMPILER##*/} -d /usr/local && \
+    rm ${PROTOBUF_COMPILER##*/}
 
 ARG TOOLCHAIN_VERSION
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true


### PR DESCRIPTION
# Description

Install up to date version of the `protoc` compiler from their github release page

## Additions and Changes

Debian repository uses outdated `protoc` compiler v3.12.4, so we install up to date version,

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
