### PR TITLE
chore: adding dummy commit to refresh scheduler

### DIFF
--- a/.github/workflows/dummy_commit.yml
+++ b/.github/workflows/dummy_commit.yml
@@ -1,0 +1,24 @@
+name: Dummy commit
+
+on:
+  schedule:
+    # Triggers the workflow every 15 days at 5:00 UTC:
+    - cron: "0 5 15 * *"
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      CI_COMMIT_MESSAGE: Continuous Integration Build trigger
+      CI_COMMIT_AUTHOR: Continuous Integration
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ROBOT_PAT_TRIGGER_E2E_WORKFLOWS }}
+      - name: Push commit to main
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "username@users.noreply.github.com"
+          git commit --allow-empty -m $CI_COMMIT_MESSAGE
+          git push


### PR DESCRIPTION
# Description

Add a github action to push a commit every 15 days in order to refresh the scheduler timeout.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
